### PR TITLE
Set preferGlobal to true in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.44",
   "description": "Vern module and project management",
   "main": "bin/vern",
+  "preferGlobal": true,
   "bin": {
     "vern": "./bin/vern"
   },


### PR DESCRIPTION
from npm docs:

preferGlobal

If your package is primarily a command-line application that should be installed globally, then set this value to true to provide a warning if it is installed locally.

It doesn't actually prevent users from installing it locally, but it does help prevent some confusion if it doesn't work as expected.